### PR TITLE
Nookipedia API replacement

### DIFF
--- a/hooks/useVillagers.js
+++ b/hooks/useVillagers.js
@@ -8,7 +8,7 @@ const nookipediaApi = async (params) => {
     const response = await fetch(nookipedia, {
         "method": "GET",
         "headers": {
-            "X-API-KEY": "process.env.NOOKIPEDIA_KEY",
+            "X-API-KEY": process.env.NOOKIPEDIA_KEY,
             "Accept-Version": "1.4.0"
         }
     })

--- a/hooks/useVillagers.js
+++ b/hooks/useVillagers.js
@@ -8,7 +8,7 @@ const nookipediaApi = async (params) => {
     const response = await fetch(nookipedia, {
         "method": "GET",
         "headers": {
-            "X-API-KEY": process.env.NOOKIPEDIA_KEY,
+            "X-API-KEY": process.env.NEXT_PUBLIC_NOOKIPEDIA_KEY,
             "Accept-Version": "1.4.0"
         }
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -559,12 +559,6 @@
         "get-intrinsic": "^1.0.2"
       }
     },
-    "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-      "dev": true
-    },
     "caniuse-lite": {
       "version": "1.0.30001269",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001269.tgz",
@@ -706,15 +700,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "2.6.1"
       }
     },
     "crypto-browserify": {
@@ -1194,12 +1179,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
-    "hyntax": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/hyntax/-/hyntax-1.1.9.tgz",
-      "integrity": "sha512-xjxyDLbVDdLgjPnl4NM+Iu6il3UPmk6PNCBXruQKeuKDc/HtaZx1hk1AtMgw3vsn9YnLZRfoBpPxYMXcoT5KAA==",
-      "dev": true
-    },
     "hyphenate-style-name": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
@@ -1224,15 +1203,6 @@
       "integrity": "sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==",
       "requires": {
         "queue": "6.0.2"
-      }
-    },
-    "infobox-parser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/infobox-parser/-/infobox-parser-3.6.1.tgz",
-      "integrity": "sha512-y/Z3iI0V4ZBjK/Un21K/a2h2iA2UItETd14shEdj6ZajrRHmysTVVmfxn0z2LsXs4Pb9byxIMb+rA+6luB3kyw==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^4.1.0"
       }
     },
     "inherits": {
@@ -2894,17 +2864,6 @@
             "define-properties": "^1.1.3"
           }
         }
-      }
-    },
-    "wikijs": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/wikijs/-/wikijs-6.3.2.tgz",
-      "integrity": "sha512-/bkbGw4DNqVl+qT1r/BLIKWInxBkQBGJZzHcjboDTHRXFSVxPkXEDwBhBHn1fcWR5iXDC9FdGbXcKoxsvazsDw==",
-      "dev": true,
-      "requires": {
-        "cross-fetch": "^3.0.2",
-        "hyntax": "^1.1.9",
-        "infobox-parser": "3.6.1"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "typeface-roboto": "0.0.75"
   },
   "devDependencies": {
-    "lodash": "^4.17.21",
-    "wikijs": "^6.3.2"
+    "lodash": "^4.17.21"
   },
   "scripts": {
     "dev": "next",


### PR DESCRIPTION
Old way: WikiJS to use Nookipedia as an "API"

New way: Fancy-shmancy [official Nookipedia API](https://api.nookipedia.com/)

🔼 This works so much better, it's glorious. Closes #5 and #6 

🔽 Should refactor to expose API key less through Vercel